### PR TITLE
switch to gunicorn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # See https://www.digitalocean.com/community/tutorials/how-to-build-and-deploy-a-flask-application-using-docker-on-ubuntu-18-04
-FROM tiangolo/uwsgi-nginx-flask:python3.7
+FROM tiangolo/meinheld-gunicorn-flask:python3.7
 
-ARG AIIDA_VERSION=1.2.1
+ARG AIIDA_VERSION=1.3.1
 
 # Install AiiDA
 RUN pip install aiida-core[rest,atomic_tools]==$AIIDA_VERSION
@@ -9,7 +9,6 @@ RUN reentry scan -r aiida
 
 # Scripts for REST API
 COPY main.py /app
-COPY uwsgi.ini /app
 
 # Container vars
 ENV AIIDA_PATH /app
@@ -25,5 +24,8 @@ ENV AIIDADB_PASS ""
 ENV AIIDADB_BACKEND django
 ENV default_user_email info@materialscloud.org
 
-# start AiiDA REST API
-EXPOSE 5000
+# GUNICORN vars 
+# Set number of gunicorn workers to 2 (overriding automatic scaling with #cores)
+# Note: memory footprint of the container scales linearly with the number of workers
+# https://github.com/tiangolo/meinheld-gunicorn-flask-docker#advanced-usage
+ENV WEB_CONCURRENCY 2


### PR DESCRIPTION
As pointed out in the README of the base image
https://github.com/tiangolo/uwsgi-nginx-flask-docker, one can gain up to
4x performance benefits by switching to
https://github.com/tiangolo/meinheld-gunicorn-flask-docker instead.

This switches to the gunicorn image, fixing the number of workers to two
(taking into account that the memory footprint of the container scales
essentially linearly with the number of workers requested).